### PR TITLE
remove inputEncoding and outputEncoding params from decipher.update call

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function Cryptr(secret) {
 
         decipher.setAuthTag(tag);
 
-        return decipher.update(encrypted, 'hex', 'utf8') + decipher.final('utf8');
+        return decipher.update(encrypted) + decipher.final('utf8');
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "aes-256",
     "aes256",
     "aes-256-ctr",
+    "aes-256-gcm",
     "hashr"
   ],
   "author": "Maurice Butler <maurice.butler@gmail.com>",

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,17 @@ test('works...', t => {
     t.equal(decryptedString, testData, 'decrypted aes256 correctly');
 });
 
+test('works with utf8 specific characters', t => {
+    t.plan(1);
+
+    const testString = 'ßáÇÖÑ 🥓';
+    const cryptr = new Cryptr(testSecret);
+    const encryptedString = cryptr.encrypt(testString);
+    const decryptedString = cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testString, 'decrypted aes256 correctly with UTF8 chars');
+});
+
 test('goes bang if bad secret', t => {
     const badSecrets = [null, undefined, 0, 123451345134, '', Buffer.from('buffer'), {}];
 


### PR DESCRIPTION
resolves #17 

Seems the behavior of decipher.update has changed in Node 13

Documentation states 
> If data is a Buffer then `inputEncoding` is ignored.

This seems to not be the case anymore...

Tested and working on node 10, 12 and 13.