### PR TITLE
Make key iterations configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ The Cryptr constructor takes 1 required argument.
 
 `Cryptr(secret)`
 
-The `salt` and `iv` are randomly generated and prepended to the result
+The `salt` and `iv` are randomly generated and prepended to the result.
+
+You can also configure the number of pbkdf2 iterations. Reducing from 100000 (default) to 10000 yields a 10x speed improvement.
+
+`Cryptr(secret, 10000)`
 
 **DO NOT USE THIS MODULE FOR ENCRYPTING PASSWORDS!**
 

--- a/index.js
+++ b/index.js
@@ -7,13 +7,17 @@ const tagLength = 16;
 const tagPosition = saltLength + ivLength;
 const encryptedPosition = tagPosition + tagLength;
 
-function Cryptr(secret) {
+function Cryptr(secret, pbkdf2Iterations) {
     if (!secret || typeof secret !== 'string') {
         throw new Error('Cryptr: secret must be a non-0-length string');
     }
 
+    if (!pbkdf2Iterations) {
+        pbkdf2Iterations = 100000
+    }
+
     function getKey(salt) {
-        return crypto.pbkdf2Sync(secret, salt, 100000, 32, 'sha512');
+        return crypto.pbkdf2Sync(secret, salt, pbkdf2Iterations, 32, 'sha512');
     }
 
     this.encrypt = function encrypt(value) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,16 @@ test('works...', t => {
     t.equal(decryptedString, testData, 'decrypted aes256 correctly');
 });
 
+test('works with custom pbkdf2Iterations', t => {
+    t.plan(1);
+
+    const cryptr = new Cryptr(testSecret, 10000);
+    const encryptedString = cryptr.encrypt(testData);
+    const decryptedString = cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testData, 'decrypted aes256 correctly');
+});
+
 test('works with utf8 specific characters', t => {
     t.plan(1);
 


### PR DESCRIPTION
The default settings are too slow for my use case. Reducing pbkdf2 iterations from 100k to 10k yields a 10x speed improvement.