### PR TITLE
Add TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+declare class Cryptr {
+	constructor(
+		secret: string,
+		options?: { pbkdf2Iterations?: number; saltLength?: number },
+	);
+
+	encrypt(value: string): string;
+
+	decrypt(value: string): string;
+}
+
+export = Cryptr;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.0",
   "description": "a simple encrypt and decrypt module for node.js",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Added types for Cryptr in `index.ts`. 
Changed package.json to add `types` property.

I do not think this is a breaking change. Only way this is a breaking change is if user uses TypeScript, but used this package incorrectly, and now his build is failing. But I do not see how that is possible, since this library would've thrown an error already. Anyone who used package properly, user old types from `@types/cryptr`, or use only js, this is not a breaking change.

But I'll leave that to you.
Closes #45 