### PR TITLE
fixed deprecated warning for the Buffer.slice method

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,10 +56,10 @@ function Cryptr(secret, options) {
 
         const stringValue = Buffer.from(String(value), 'hex');
 
-        const salt = stringValue.slice(0, saltLength);
-        const iv = stringValue.slice(saltLength, tagPosition);
-        const tag = stringValue.slice(tagPosition, encryptedPosition);
-        const encrypted = stringValue.slice(encryptedPosition);
+        const salt = stringValue.subarray(0, saltLength);
+        const iv = stringValue.subarray(saltLength, tagPosition);
+        const tag = stringValue.subarray(tagPosition, encryptedPosition);
+        const encrypted = stringValue.subarray(encryptedPosition);
 
         const key = getKey(salt);
 


### PR DESCRIPTION
Moved to `Buffer.subarray` method of the Buffer API instead of the deprecated (since v16.x) method `Buffer.slice`.

```js
// Deprecated "slice" method: @since v0.3.0
const buffer = Buffer.from('xxxxx', 'hex');
const bufferPart = buffer.slice(0, 16);
```

```js
// Recommended "subarray" method: @since v3.0.0
const buffer = Buffer.from('xxxxx', 'hex');
const bufferPart = buffer.subarray(0, 16);
```