### PR TITLE
Allow encoding to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Cryptr constructor takes 1 required argument, and an optional options object
 
 -   secret: `<string>`
 -   options: `<Object>`
+    -   encoding: `<string>` Defaults to 'hex' (see [Node.js Buffer documentation] for valid options)
     -   pbkdf2Iterations: `<number>` Defaults to 100000
     -   saltLength: `<number>` Defaults to 64
 
@@ -42,11 +43,13 @@ console.log(decryptedString); // bacon
 
 ```javascript
 const Cryptr = require('cryptr');
-const cryptr = new Cryptr('myTotallySecretKey', { pbkdf2Iterations: 10000, saltLength: 10 });
+const cryptr = new Cryptr('myTotallySecretKey', { encoding: 'base64', pbkdf2Iterations: 10000, saltLength: 10 });
 
 const encryptedString = cryptr.encrypt('bacon');
 const decryptedString = cryptr.decrypt(encryptedString);
 
-console.log(encryptedString); // 33b2c319908e72e899db0cad10dd1e24a999cd4922d64c6fbe261020f97ed4fdfe07124268df34bae00ee09f9d91a7
+console.log(encryptedString); // CPbKO/FFLQ8lVKxV+jYJcLcpTU0ZvW3D+JVfUecmJmLYY10UxYEa/wf8PWDQqhw=
 console.log(decryptedString); // bacon
 ```
+
+[Node.js Buffer documentation]: https://nodejs.org/api/buffer.html#buffers-and-character-encodings

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const algorithm = 'aes-256-gcm';
 const ivLength = 16;
 const tagLength = 16;
+const defaultEncoding = 'hex';
 const defaultSaltLength = 64;
 const defaultPbkdf2Iterations = 100000;
 
@@ -11,10 +12,15 @@ function Cryptr(secret, options) {
         throw new Error('Cryptr: secret must be a non-0-length string');
     }
 
+    let encoding = defaultEncoding;
     let saltLength = defaultSaltLength;
     let pbkdf2Iterations = defaultPbkdf2Iterations;
 
     if (options) {
+        if (options.encoding) {
+          encoding = options.encoding;
+        }
+
         if (options.pbkdf2Iterations) {
             pbkdf2Iterations = options.pbkdf2Iterations;
         }
@@ -46,7 +52,7 @@ function Cryptr(secret, options) {
 
         const tag = cipher.getAuthTag();
 
-        return Buffer.concat([salt, iv, tag, encrypted]).toString('hex');
+        return Buffer.concat([salt, iv, tag, encrypted]).toString(encoding);
     };
 
     this.decrypt = function decrypt(value) {
@@ -54,7 +60,7 @@ function Cryptr(secret, options) {
             throw new Error('value must not be null or undefined');
         }
 
-        const stringValue = Buffer.from(String(value), 'hex');
+        const stringValue = Buffer.from(String(value), encoding);
 
         const salt = stringValue.slice(0, saltLength);
         const iv = stringValue.slice(saltLength, tagPosition);

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,6 +14,27 @@ test('works...', (t) => {
     t.equal(decryptedString, testData, 'decrypted aes256 correctly');
 });
 
+test('works with custom encoding', (t) => {
+  t.plan(1);
+
+  const cryptr = new Cryptr(testSecret, { encoding: 'base64' });
+  const encryptedString = cryptr.encrypt(testData);
+  const decryptedString = cryptr.decrypt(encryptedString);
+
+  t.equal(decryptedString, testData, 'decrypted aes256 correctly with custom encoding');
+});
+
+test('custom encoding affects output length', (t) => {
+  t.plan(1);
+
+  const cryptr = new Cryptr(testSecret, { encoding: 'base64' });
+  const cryptr2 = new Cryptr(testSecret);
+  const encryptedString = cryptr.encrypt(testData);
+  const encryptedString2 = cryptr2.encrypt(testData);
+
+  t.ok(encryptedString.length < encryptedString2.length, 'custom encoding was shorter');
+});
+
 test('works with custom pbkdf2Iterations', (t) => {
     t.plan(1);
 


### PR DESCRIPTION
It can be beneficial to change the encoding, from 'hex' to 'base64' (for example) as this can greatly reduce the size of the encrypted string. (Which is useful to me as I'm using cryptr to encrypt cookies, which have a 4kiB size limit.)

This PR adds a configuration option to allow this, along with some unit tests. The README has also been updated to document the new option.

If you like this change, it might also be worth considering changing the default from 'hex'. (Unless there is some benefit to 'hex' despite the larger strings?) That would potentially constitute a breaking change though.