### PR TITLE
Add CryptrAsync class for off-thread operation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,4 +9,19 @@ declare class Cryptr {
     decrypt(value: string): string;
 }
 
+declare class CryptrAsync {
+    constructor(
+        secret: string,
+        options?: { pbkdf2Iterations?: number; saltLength?: number; encoding?: 'hex' | 'base64' | 'latin1' },
+    );
+
+    async encrypt(value: string): Promise<string>;
+
+    async decrypt(value: string): Promise<string>;
+}
+
+declare namespace Cryptr {
+    export { CryptrAsync };
+}
+
 export = Cryptr;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const util = require('util');
 
 const algorithm = 'aes-256-gcm';
 const ivLength = 16;
@@ -77,4 +78,76 @@ function Cryptr(secret, options) {
     };
 }
 
+function CryptrAsync(secret, options) {
+    if (!secret || typeof secret !== 'string') {
+        throw new Error('Cryptr: secret must be a non-0-length string');
+    }
+
+    let encoding = defaultEncoding;
+    let saltLength = defaultSaltLength;
+    let pbkdf2Iterations = defaultPbkdf2Iterations;
+
+    if (options) {
+        if (options.encoding) {
+            encoding = options.encoding;
+        }
+
+        if (options.pbkdf2Iterations) {
+            pbkdf2Iterations = options.pbkdf2Iterations;
+        }
+
+        if (options.saltLength) {
+            saltLength = options.saltLength;
+        }
+    }
+
+    const tagPosition = saltLength + ivLength;
+    const encryptedPosition = tagPosition + tagLength;
+
+    async function getKey(salt) {
+        const pbkdf2 = util.promisify(crypto.pbkdf2);
+        return await pbkdf2(secret, salt, pbkdf2Iterations, 32, 'sha512');
+    }
+
+    this.encrypt = async function encrypt(value) {
+        if (value == null) {
+            throw new Error('value must not be null or undefined');
+        }
+
+        const iv = crypto.randomBytes(ivLength);
+        const salt = crypto.randomBytes(saltLength);
+
+        const key = await getKey(salt);
+
+        const cipher = crypto.createCipheriv(algorithm, key, iv);
+        const encrypted = Buffer.concat([cipher.update(String(value), 'utf8'), cipher.final()]);
+
+        const tag = cipher.getAuthTag();
+
+        return Buffer.concat([salt, iv, tag, encrypted]).toString(encoding);
+    };
+
+    this.decrypt = async function decrypt(value) {
+        if (value == null) {
+            throw new Error('value must not be null or undefined');
+        }
+
+        const stringValue = Buffer.from(String(value), encoding);
+
+        const salt = stringValue.subarray(0, saltLength);
+        const iv = stringValue.subarray(saltLength, tagPosition);
+        const tag = stringValue.subarray(tagPosition, encryptedPosition);
+        const encrypted = stringValue.subarray(encryptedPosition);
+
+        const key = await getKey(salt);
+
+        const decipher = crypto.createDecipheriv(algorithm, key, iv);
+
+        decipher.setAuthTag(tag);
+
+        return decipher.update(encrypted) + decipher.final('utf8');
+    };
+}
+
 module.exports = Cryptr;
+module.exports.CryptrAsync = CryptrAsync;

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,6 @@
 const test = require('tape');
 const Cryptr = require('../');
+const CryptrAsync = require('../').CryptrAsync;
 
 const testSecret = 'myTotalySecretKey';
 const testData = 'bacon';
@@ -175,6 +176,199 @@ test('decrypt goes bang if value has been tampered with', (t) => {
     t.throws(
         () => cryptr.decrypt(modifiedValue),
         /Unsupported state or unable to authenticate data/,
+        'throws on tampered data',
+    );
+});
+
+test('async works...', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret);
+    const encryptedString = await cryptr.encrypt(testData);
+    const decryptedString = await cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testData, 'decrypted aes256 correctly');
+});
+
+test('async works with custom encoding', async (t) => {
+    const encodings = ['hex', 'base64', 'latin1'];
+
+    t.plan(encodings.length);
+
+    for (const encoding of encodings) {
+        const cryptr = new CryptrAsync(testSecret, { encoding });
+        const encryptedString = await cryptr.encrypt(testData);
+        const decryptedString = await cryptr.decrypt(encryptedString);
+
+        t.equal(decryptedString, testData, `decrypted correctly with ${encoding} encoding`);
+    }
+});
+
+test('async custom encoding affects output length', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret, { encoding: 'base64' });
+    const cryptr2 = new CryptrAsync(testSecret);
+    const encryptedString = await cryptr.encrypt(testData);
+    const encryptedString2 = await cryptr2.encrypt(testData);
+
+    t.ok(encryptedString.length < encryptedString2.length, 'custom encoding was shorter');
+});
+
+test('async works with custom pbkdf2Iterations', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret, { pbkdf2Iterations: 10000 });
+    const encryptedString = await cryptr.encrypt(testData);
+    const decryptedString = await cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testData, 'decrypted aes256 correctly with custom iterations');
+});
+
+test('async custom pbkdf2Iterations affects speed', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret, { pbkdf2Iterations: 1000 });
+    const cryptr2 = new CryptrAsync(testSecret);
+    const customStart = performance.now();
+    for (let index = 0; index < 10; index++) {
+        const encryptedString = await cryptr.encrypt(testData + index);
+        await cryptr.decrypt(encryptedString);
+    }
+    const customEnd = performance.now();
+
+    const defaultStart = performance.now();
+    for (let index = 0; index < 10; index++) {
+        const encryptedString = await cryptr2.encrypt(testData + index);
+        await cryptr2.decrypt(encryptedString);
+    }
+    const defaultEnd = performance.now();
+
+    const customTime = customEnd - customStart;
+    const defaultTime = defaultEnd - defaultStart;
+
+    t.ok(customTime < defaultTime, 'custom iterations were faster');
+});
+
+test('async works with custom saltLength', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret, { saltLength: 10 });
+    const encryptedString = await cryptr.encrypt(testData);
+    const decryptedString = await cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testData, 'decrypted aes256 correctly with custom salt length');
+});
+
+test('async custom saltLength affects output length', async (t) => {
+    t.plan(1);
+
+    const customSaltLength = 30;
+    const cryptr = new CryptrAsync(testSecret, { saltLength: customSaltLength });
+    const cryptr2 = new CryptrAsync(testSecret);
+    const encryptedString = await cryptr.encrypt(testData);
+    const encryptedString2 = await cryptr2.encrypt(testData);
+
+    t.equal(
+        encryptedString2.length - encryptedString.length,
+        (64 - customSaltLength) * 2,
+        'output length is affected by salt length',
+    );
+});
+
+test('async works with utf8 specific characters', async (t) => {
+    t.plan(1);
+
+    const testString = 'ßáÇÖÑ 🥓';
+    const cryptr = new CryptrAsync(testSecret);
+    const encryptedString = await cryptr.encrypt(testString);
+    const decryptedString = await cryptr.decrypt(encryptedString);
+
+    t.equal(decryptedString, testString, 'decrypted aes256 correctly with UTF8 chars');
+});
+
+test('async goes bang if bad secret', async (t) => {
+    const badSecrets = [null, undefined, 0, 123451345134, '', Buffer.from('buffer'), {}];
+
+    t.plan(badSecrets.length);
+
+    for (let i = 0; i < badSecrets.length; i++) {
+        t.throws(
+            () => new CryptrAsync(badSecrets[i]),
+            /Cryptr: secret must be a non-0-length string/,
+            `throws on bad secret ${badSecrets[i]}`,
+        );
+    }
+});
+
+test('async encrypt goes bang if value is null or undefined', async (t) => {
+    const cryptr = new CryptrAsync(testSecret);
+    const badValues = [null, undefined];
+
+    t.plan(badValues.length);
+
+    for (let i = 0; i < badValues.length; i++) {
+        let value;
+        try {
+            value = await cryptr.encrypt(badValues[i]);
+        } catch (e) {
+            value = e;
+        }
+        t.assert(
+            value instanceof Error &&
+                value.message === 'value must not be null or undefined',
+            `throws on value ${badValues[i]}`,
+        );
+    }
+});
+
+test('async decrypt goes bang if value is null or undefined', async (t) => {
+    const cryptr = new CryptrAsync(testSecret);
+    const badValues = [null, undefined];
+
+    t.plan(badValues.length);
+
+    for (let i = 0; i < badValues.length; i++) {
+        let value;
+        try {
+            value = await cryptr.decrypt(badValues[i]);
+        } catch (e) {
+            value = e;
+        }
+        t.assert(
+            value instanceof Error &&
+                value.message === 'value must not be null or undefined',
+            `throws on value ${badValues[i]}`,
+        );
+    }
+});
+
+test('async decrypt goes bang if value has been tampered with', async (t) => {
+    t.plan(1);
+
+    const cryptr = new CryptrAsync(testSecret);
+
+    const encryptedString = await cryptr.encrypt(testData);
+
+    const encryptedBuffer = Buffer.from(encryptedString, 'hex');
+    const b1 = Buffer.from(testData);
+    const b2 = Buffer.from('hello');
+
+    for (let i = 0; i < b1.length; i++) {
+        encryptedBuffer[i + 16] ^= b1[i] ^ b2[i];
+    }
+
+    const modifiedValue = encryptedBuffer.toString('hex');
+
+    let value;
+    try {
+        value = await cryptr.decrypt(modifiedValue);
+    } catch (e) {
+        value = e;
+    }
+    t.assert(
+        value instanceof Error &&
+            value.message === 'Unsupported state or unable to authenticate data',
         'throws on tampered data',
     );
 });


### PR DESCRIPTION
Adds a new `CryptrAsync` class that uses `crypto.pbkdf2` which runs in the `libuv` threadpool (instead of `crypto.pbkdf2Sync` which runs on the main-thread).

Makes `CryptoAsync` a named export to keep backwards compatibility, but will require `async` and `await` to be defined (Node 7.6.0+)